### PR TITLE
PHP 7.4 kompatibilita - Správné pořadí funkce join

### DIFF
--- a/src/GopayHelper.php
+++ b/src/GopayHelper.php
@@ -650,7 +650,7 @@ class GopayHelper
 		$lang
 	)
 	{
-		$paymentChannelsString = (!empty($paymentChannels)) ? join($paymentChannels, ',') : '';
+		$paymentChannelsString = (!empty($paymentChannels)) ? join(',', $paymentChannels) : '';
 
 		$encryptedSignature = self::encrypt(
 			self::hash(
@@ -784,7 +784,7 @@ class GopayHelper
 		$lang
 	)
 	{
-		$paymentChannelsString = (!empty($paymentChannels)) ? join($paymentChannels, ',') : '';
+		$paymentChannelsString = (!empty($paymentChannels)) ? join(',', $paymentChannels) : '';
 
 		$encryptedSignature = self::encrypt(
 			self::hash(

--- a/src/GopaySoap.php
+++ b/src/GopaySoap.php
@@ -380,7 +380,7 @@ class GopaySoap
 		try {
 			ini_set('soap.wsdl_cache_enabled', '0');
 			$go_client = GopayConfig::createSoapClient();
-			$paymentChannelsString = (!empty($paymentChannels)) ? join($paymentChannels, ',') : '';
+			$paymentChannelsString = is_array($paymentChannels) ? join(',', $paymentChannels) : '';
 
 			/*
 			 * Sestaveni pozadavku pro zalozeni platby


### PR DESCRIPTION
Úpravy pro kompatiblitu s PHP 7.4. Jsou zpětně kompatibilní pro starší verze PHP.