### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
-![](https://heatbadger.now.sh/github/readme/contributte/gopay-api/)
+![](https://heatbadger.now.sh/github/readme/contributte/gopay-api/?deprecated=1)
 
 <p align=center>
-  <a href="https://github.com/contributte/gopay-api/actions"><img src="https://badgen.net/github/checks/contributte/gopay-api/master?cache=300"></a>
-  <a href="https://coveralls.io/r/contributte/gopay-api"><img src="https://badgen.net/coveralls/c/github/contributte/gopay-api?cache=300"></a>
-  <a href="https://packagist.org/packages/markette/gopay-api"><img src="https://badgen.net/packagist/dm/markette/gopay-api"></a>
-  <a href="https://packagist.org/packages/markette/gopay-api"><img src="https://badgen.net/packagist/v/markette/gopay-api"></a>
-</p>
-<p align=center>
-  <a href="https://packagist.org/packages/markette/gopay-api"><img src="https://badgen.net/packagist/php/markette/gopay-api"></a>
-  <a href="https://github.com/contributte/gopay-api"><img src="https://badgen.net/github/license/contributte/gopay-api"></a>
-  <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
-  <a href="https://bit.ly/cttfo"><img src="https://badgen.net/badge/support/forum/yellow"></a>
-  <a href="https://contributte.org/partners.html"><img src="https://badgen.net/badge/sponsor/donations/F96854"></a>
+    <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
+    <a href="https://bit.ly/cttfo"><img src="https://badgen.net/badge/support/forum/yellow"></a>
+    <a href="https://contributte.org/partners.html"><img src="https://badgen.net/badge/sponsor/donations/F96854"></a>
 </p>
 
 <p align=center>
-Website 🚀 <a href="https://contributte.org">contributte.org</a> | Contact 👨🏻‍💻 <a href="https://f3l1x.io">f3l1x.io</a> | Twitter 🐦 <a href="https://twitter.com/contributte">@contributte</a>
+    Website 🚀 <a href="https://contributte.org">contributte.org</a> | Contact 👨🏻‍💻 <a href="https://f3l1x.io">f3l1x.io</a> | Twitter 🐦 <a href="https://twitter.com/contributte">@contributte</a>
 </p>
+
+## Disclaimer
+
+| :warning: | This project is no longer being maintained. Please use [gopay-php-api](https://github.com/gopaycommunity/gopay-php-api).|
+|---|---|
+
+| Composer | [`markette/gopay-api`](https://packagist.org/packages/markette/gopay-api) |
+|---| --- |
+| Version | ![](https://badgen.net/packagist/v/markette/gopay-api) |
+| PHP | ![](https://badgen.net/packagist/php/markette/gopay-api) |
+| License | ![](https://badgen.net/github/license/contributte/gopay-api) |
 
 ## Usage
 
@@ -41,13 +44,13 @@ composer require markette/gopay-api
 
 ## Development
 
-See [how to contribute](https://contributte.org) to this package. This package is currently maintained by these authors.
+This package was maintained by these authors.
 
 <a href="https://github.com/f3l1x">
-    <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
+  <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
 </a>
 
 -----
 
-Consider to [support](https://contributte.org/partners) **contributte** development team.
+Consider to [support](https://contributte.org/partners.html) **contributte** development team.
 Also thank you for using this package.


### PR DESCRIPTION
This PR converts the README to archive style following the standardized template.

## Changes
- Added deprecation badge with `?deprecated=1` parameter
- Added disclaimer section indicating the project is no longer maintained
- Added reference to replacement package: gopay-php-api (official Gopay PHP SDK)
- Added Composer package info table with badges
- Updated Development section to past tense ("was maintained")
- Preserved all original documentation (Usage, Documentation, Versions)

The repository can be archived after this PR is merged.